### PR TITLE
improve first title slide

### DIFF
--- a/LaTeX/Ubucon.Sintra.2019.tex
+++ b/LaTeX/Ubucon.Sintra.2019.tex
@@ -17,7 +17,7 @@
 
 %Information to be included in the title page:
 \title{This is the Title of the Talk or Workshop}
-\author{presentation by: Speaker on Ubucon Europe 2019}
+\author{Speaker on Ubucon Europe 2019}
 
 \begin{document}
 \frame[plain]{\titlepage}

--- a/LaTeX/beamerthemeUbuntu.sty
+++ b/LaTeX/beamerthemeUbuntu.sty
@@ -11,6 +11,9 @@
 \usefonttheme{professionalfonts}
 
 \usepackage{fontspec}
+\usepackage[absolute,overlay]{textpos}
+% Uncomment this to show a grid (useful for debugging textpos):
+% \usepackage[texcoord,grid,gridunit=mm,gridcolor=red!10,subgridcolor=green!10]{eso-pic}
 
 \setmainfont[Mapping=tex-text]{Ubuntu}
 
@@ -53,12 +56,14 @@
     \includegraphics[keepaspectratio, width=\paperwidth, height=\paperheight]{bg-title.png}
   \end{beamercolorbox}
   \vskip-7cm%
-  \begin{beamercolorbox}[leftskip=5cm,wd=15cm]{title}
-    \usebeamerfont{title}\inserttitle
-  \end{beamercolorbox}
-  \begin{beamercolorbox}[]{author}
-    \usebeamerfont{author}\begin{flushright}\insertauthor\end{flushright}
-  \end{beamercolorbox}
+  \begin{textblock*}{80mm}(65mm,30mm)
+    \begin{beamercolorbox}{title}
+    \usebeamerfont{title}\begin{flushright}\textbf{\inserttitle}\end{flushright}
+    \end{beamercolorbox}
+    \begin{beamercolorbox}[]{author}
+    \usebeamerfont{author}\begin{flushright}\scriptsize presentation by: \insertauthor\end{flushright}
+    \end{beamercolorbox}
+  \end{textblock*}
   \vskip7cm%
   \vfill
 }


### PR DESCRIPTION
Improve title slide
note the commented line in `beamerthemeUbuntu.sty` (line 16): useful for debugging absolute positions and dimensions 